### PR TITLE
Replace curl with native Go http client for proxy support and better error handling

### DIFF
--- a/pkg/msbimport/util.go
+++ b/pkg/msbimport/util.go
@@ -87,9 +87,7 @@ func httpGetAndroidUA(link string) (string, error) {
 }
 
 func fDownload(link string, savePath string) error {
-	cmd := exec.Command("curl", "-o", savePath, link)
-	_, err := cmd.CombinedOutput()
-	return err
+	return httpDownloadCurlUA(link, savePath)
 }
 
 func fExtract(f string) string {


### PR DESCRIPTION
### What this PR does
Replaced the `exec.Command("curl"... )` implementation in `fDownload` with the already existing native Go method `httpDownloadCurlUA`.

### Why is this needed?
1. External OS `curl` ignores Docker/host `HTTP_PROXY`/`HTTPS_PROXY` configs, breaking extraction workflows when users deploy inside restricted network nodes.
2. Failed curl commands only output a non-descriptive `exit status 1` and swallow the root network cause from users. 
3. This change leverages Go native `net/http` to provide implicit proxy routing, proper redirection tracking, explicit granular error bubbling, and properly spoofed user-agent headers. 

Tested locally via customized Docker builds. Works flawlessly around strict network firewalls!